### PR TITLE
fix GenProofRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ message GetStatusResponse {
 ```
 /**
  * @dev GenProofRequest
- * @param {id} - proof identifier
+ * @param {input} - input prover
  */
 message GenProofRequest {
-    string id = 1;
+    InputProver input = 1;
 }
 ```
 

--- a/proto/zkprover/v1/zk_prover.proto
+++ b/proto/zkprover/v1/zk_prover.proto
@@ -37,10 +37,10 @@ message GetStatusRequest {}
 
 /**
  * @dev GenProofRequest
- * @param {id} - proof identifier
+ * @param {input} - input prover
  */
 message GenProofRequest {
-    string id = 1;
+    InputProver input = 1;
 }
 
 /**


### PR DESCRIPTION
This PR does the following:
- fix input for `GenProofRequest` which should be an `InputProver` data type