### PR TITLE
Change type for unprocessed_transaction from bool to uint32

### DIFF
--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -17,9 +17,9 @@ message ProcessBatchRequest {
     bytes global_exit_root = 5;
     bytes old_local_exit_root = 6;
     uint64 eth_timestamp = 7;
-    bool update_merkle_tree = 8;
-    bool generate_execute_trace = 9;
-    bool generate_call_trace = 10;
+    uint32 update_merkle_tree = 8;
+    uint32 generate_execute_trace = 9;
+    uint32 generate_call_trace = 10;
     // For testing purposes only
     map<string, string> db = 11; 
 }


### PR DESCRIPTION
Changes type for unprocessed_transaction from bool to uint32 as there seem to be problems unmarshalling the response with this type.