### PR TITLE
add address aggregator

### DIFF
--- a/proto/zkprover/v1/zk_prover.proto
+++ b/proto/zkprover/v1/zk_prover.proto
@@ -206,6 +206,7 @@ message Proof {
  * @param {public_inputs} - public inputs
  * @param {global_exit_root} - bridge global exit root
  * @param {batch_l2_data} - contract calldata
+ * @param {address_aggregator} - ethereum address aggregator
  * @param {db} - database containing all key-values in smt matching the old state root
  * @param {contracts_bytecode} - key is the hash(contractBytecode), value is the bytecode itself
  */
@@ -213,8 +214,9 @@ message InputProver {
     PublicInputs public_inputs = 1;
     string global_exit_root = 2;
     string batch_l2_data = 3;
-    map<string, string> db = 4; // For debug/testing purpposes only. Don't fill this on production
-    map<string, string> contracts_bytecode = 5; // For debug/testing purpposes only. Don't fill this on production
+    string address_aggregator = 4;
+    map<string, string> db = 5; // For debug/testing purpposes only. Don't fill this on production
+    map<string, string> contracts_bytecode = 6; // For debug/testing purpposes only. Don't fill this on production
 }
 
 /**


### PR DESCRIPTION
This PR does the following:
- adds `address_aggregator` parameter to the `InputProver` when requesting a proof
- Note that this parameter **must** be the Ethereum address of the aggregator that sends the `verifyBatch` transaction to the smart contract
- It is used to avoid proof front-running