### PR TITLE
recursive inputs

### DIFF
--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -10,30 +10,31 @@ service ExecutorService {
 }
 
 message ProcessBatchRequest {
-    uint64 batch_num = 1;
-    string coinbase = 2;
-    bytes batch_l2_data = 3;
-    // from is used for unsigned transactions with sender
-    string from = 4;
-    bytes old_state_root = 5;
+    bytes old_state_root = 1;
+    bytes old_acc_input_hash = 2;
+    uint64 old_batch_num = 3;
+    uint64 chain_id = 4;
+    bytes batch_l2_data = 5;
     bytes global_exit_root = 6;
-    bytes old_local_exit_root = 7;
-    uint64 eth_timestamp = 8;
+    uint64 eth_timestamp = 7;
+    string coinbase = 8;
     uint32 update_merkle_tree = 9;
     bytes tx_hash_to_generate_execute_trace = 10;
     bytes tx_hash_to_generate_call_trace = 11;
+    // flag to indicate that counters should not be taken into account
+    uint64 no_counters = 12;
+    // from is used for unsigned transactions with sender
+    string from = 13;
     // For testing purposes only
-    map<string, string> db = 12;
-    map<string, string> contracts_bytecode = 13; // For debug/testing purpposes only. Don't fill this on production
-    uint64 chain_id = 14;
-    uint64 no_counters = 15;
+    map<string, string> db = 14;
+    map<string, string> contracts_bytecode = 15; // For debug/testing purpposes only. Don't fill this on production
 }
 
 message ProcessBatchResponse {
-    uint64 cumulative_gas_used = 1;
-    repeated ProcessTransactionResponse responses = 2;
-    bytes new_state_root = 3;
-    bytes new_local_exit_root = 4;
+    bytes new_state_root = 1;
+    bytes new_acc_input_hash = 2;
+    bytes new_local_exit_root = 3;
+    uint64 new_batch_num = 4;
     uint32 cnt_keccak_hashes = 5;
     uint32 cnt_poseidon_hashes = 6;
     uint32 cnt_poseidon_paddings = 7;
@@ -41,7 +42,9 @@ message ProcessBatchResponse {
     uint32 cnt_arithmetics = 9;
     uint32 cnt_binaries = 10;
     uint32 cnt_steps = 11;
-    Error error = 12;
+    uint64 cumulative_gas_used = 12;
+    repeated ProcessTransactionResponse responses = 13;
+    Error error = 14;
 }
 
 message CallTrace {
@@ -240,9 +243,9 @@ enum Error {
     // ERROR_INTRINSIC_INVALID_BALANCE indicates the transaction is failing at balance intrinsic check
     ERROR_INTRINSIC_INVALID_BALANCE = 25;
     // ERROR_INTRINSIC_INVALID_BATCH_GAS_LIMIT indicates the batch is exceeding the batch gas limit
-    ERROR_INTRINSIC_INVALID_BATCH_GAS_LIMIT = 26; 
+    ERROR_INTRINSIC_INVALID_BATCH_GAS_LIMIT = 26;
     // ERROR_INTRINSIC_INVALID_SENDER_CODE indicates the batch is exceeding the batch gas limit
-    ERROR_INTRINSIC_INVALID_SENDER_CODE = 27; 
+    ERROR_INTRINSIC_INVALID_SENDER_CODE = 27;
     // ERROR_BATCH_DATA_TOO_BIG indicates the batch_l2_data is too big to be processed
     ERROR_BATCH_DATA_TOO_BIG = 28;
 }

--- a/proto/zkprover/v1/zk_prover.proto
+++ b/proto/zkprover/v1/zk_prover.proto
@@ -213,8 +213,8 @@ message Proof {
  */
 message InputProver {
     PublicInputs public_inputs = 1;
-    map<string, string> db = 4; // For debug/testing purpposes only. Don't fill this on production
-    map<string, string> contracts_bytecode = 5; // For debug/testing purpposes only. Don't fill this on production
+    map<string, string> db = 2; // For debug/testing purpposes only. Don't fill this on production
+    map<string, string> contracts_bytecode = 3; // For debug/testing purpposes only. Don't fill this on production
 }
 
 /**

--- a/proto/zkprover/v1/zk_prover.proto
+++ b/proto/zkprover/v1/zk_prover.proto
@@ -164,25 +164,24 @@ message GetProofResponse {
 /*
  * @dev PublicInputs
  * @param {old_state_root}
- * @param {old_local_exit_root}
- * @param {new_state_root}
- * @param {new_local_exit_root}
+ * @param {old_acc_input_hash}
+ * @param {old_batch_num}
+ * @param {chain_id}
+ * @param {batch_l2_data}
+ * @param {global_exit_root}
  * @param {sequencer_addr}
- * @param {batch_hash_data}
- * @param {batch_num}
- * @param {eth_timestamp}
+ * @param {aggregator_addr}
  */
 message PublicInputs {
-    string old_state_root = 1;
-    string old_local_exit_root = 2;
-    string new_state_root = 3;
-    string new_local_exit_root = 4;
-    string sequencer_addr = 5;
-    string batch_hash_data = 6;
-    uint32 batch_num = 7;
-    uint64 eth_timestamp = 8;
+    bytes old_state_root = 1;
+    bytes old_acc_input_hash = 2;
+    uint64 old_batch_num = 3;
+    uint64 chain_id = 4;
+    bytes batch_l2_data = 5;
+    bytes global_exit_root = 6;
+    uint64 eth_timestamp = 7;
+    string sequencer_addr = 8;
     string aggregator_addr = 9;
-    uint64 chain_id = 10;
 }
 
 /**
@@ -208,16 +207,12 @@ message Proof {
 /**
  * @dev InputProver
  * @param {public_inputs} - public inputs
- * @param {global_exit_root} - bridge global exit root
- * @param {batch_l2_data} - contract calldata
  * @param {address_aggregator} - ethereum address aggregator
  * @param {db} - database containing all key-values in smt matching the old state root
  * @param {contracts_bytecode} - key is the hash(contractBytecode), value is the bytecode itself
  */
 message InputProver {
     PublicInputs public_inputs = 1;
-    string global_exit_root = 2;
-    string batch_l2_data = 3;
     map<string, string> db = 4; // For debug/testing purpposes only. Don't fill this on production
     map<string, string> contracts_bytecode = 5; // For debug/testing purpposes only. Don't fill this on production
 }
@@ -225,9 +220,15 @@ message InputProver {
 /**
  * @dev PublicInputsExtended
  * @param {public_inputs} - public inputs
- * @param {input_hash} - global hash of all public inputs. Used as a sanity check.
+ * @param {new_state_root} - final state root. Used as a sanity check.
+ * @param {new_acc_input_hash} - final accumulate input hash. Used as a sanity check.
+ * @param {new_local_exit_root} - new local exit root. Used as a sanity check.
+ * @param {new_batch_num} - final num batch. Used as a sanity check.
  */
 message PublicInputsExtended {
     PublicInputs public_inputs = 1;
-    string input_hash = 2;
+    bytes new_state_root = 2;
+    bytes new_acc_input_hash = 3;
+    bytes new_local_exit_root = 4;
+    uint64 new_batch_num = 5;
 }


### PR DESCRIPTION
This PR does the following:
- adapts `executor` & `zk_prover` proto to the new `recursive` requirements
- order input fields
- normalize input types between `executor` & `zk_prover`