### PR TITLE
separate general invalid error codes

### DIFF
--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -199,53 +199,50 @@ enum Error {
     ERROR_STACK_OVERFLOW = 3;
     // ERROR_STACK_UNDERFLOW indicates a stack overflow has happened
     ERROR_STACK_UNDERFLOW = 4;
-    // ERROR_NOT_ENOUGH_FUNDS indicates there is not enough funds to continue the execution
-    ERROR_NOT_ENOUGH_FUNDS = 5;
-    // ERROR_INSUFFICIENT_BALANCE indicates there is not enough balance to continue the execution
-    ERROR_INSUFFICIENT_BALANCE = 6;
-    // ERROR_CODE_NOT_FOUND indicates the code was not found
-    ERROR_CODE_NOT_FOUND = 7;
     // ERROR_MAX_CODE_SIZE_EXCEEDED indicates the code size is beyond the maximum
-    ERROR_MAX_CODE_SIZE_EXCEEDED = 8;
+    ERROR_MAX_CODE_SIZE_EXCEEDED = 5;
     // ERROR_CONTRACT_ADDRESS_COLLISION there is a collision regarding contract addresses
-    ERROR_CONTRACT_ADDRESS_COLLISION = 9;
-    // ERROR_DEPTH indicates the maximun call depth has been passed
-    ERROR_DEPTH= 10;
+    ERROR_CONTRACT_ADDRESS_COLLISION = 6;
     // ERROR_EXECUTION_REVERTED indicates the execution has been reverted
-    ERROR_EXECUTION_REVERTED = 11;
-    // ERROR_CODE_STORE_OUT_OF_GAS indicates there is not enough gas for the storage
-    ERROR_CODE_STORE_OUT_OF_GAS = 12;
+    ERROR_EXECUTION_REVERTED = 7;
     // ERROR_OUT_OF_COUNTERS_STEP indicates there is not enough step counters to continue the execution
-    ERROR_OUT_OF_COUNTERS_STEP = 13;
+    ERROR_OUT_OF_COUNTERS_STEP = 8;
     // ERROR_OUT_OF_COUNTERS_KECCAK indicates there is not enough keccak counters to continue the execution
-    ERROR_OUT_OF_COUNTERS_KECCAK = 14;
+    ERROR_OUT_OF_COUNTERS_KECCAK = 9;
     // ERROR_OUT_OF_COUNTERS_BINARY indicates there is not enough binary counters to continue the execution
-    ERROR_OUT_OF_COUNTERS_BINARY = 15;
+    ERROR_OUT_OF_COUNTERS_BINARY = 10;
     // ERROR_OUT_OF_COUNTERS_MEM indicates there is not enough memory aligncounters to continue the execution
-    ERROR_OUT_OF_COUNTERS_MEM = 16;
+    ERROR_OUT_OF_COUNTERS_MEM = 11;
     // ERROR_OUT_OF_COUNTERS_ARITH indicates there is not enough arith counters to continue the execution
-    ERROR_OUT_OF_COUNTERS_ARITH = 17;
+    ERROR_OUT_OF_COUNTERS_ARITH = 12;
     // ERROR_OUT_OF_COUNTERS_PADDING indicates there is not enough padding counters to continue the execution
-    ERROR_OUT_OF_COUNTERS_PADDING = 18;
+    ERROR_OUT_OF_COUNTERS_PADDING = 13;
     // ERROR_OUT_OF_COUNTERS_POSEIDON indicates there is not enough poseidon counters to continue the execution
-    ERROR_OUT_OF_COUNTERS_POSEIDON = 19;
-    // ERROR_INVALID_TX indicates the transaction is invalid because of invalid jump dest, invalid opcode, invalid deploy
-    // or invalid static tx
-    ERROR_INVALID_TX = 20;
+    ERROR_OUT_OF_COUNTERS_POSEIDON = 14;
+    // ERROR_INVALID_JUMP indicates there is an invalid jump opcode
+    ERROR_INVALID_JUMP = 15;
+    // ERROR_INVALID_OPCODE indicates there is an invalid opcode
+    ERROR_INVALID_OPCODE = 16;
+    // ERROR_INVALID_STATIC indicates there is an invalid static call
+    ERROR_INVALID_STATIC = 17;
+    // ERROR_INVALID_BYTECODE_STARTS_EF indicates there is a bytecode starting with 0xEF
+    ERROR_INVALID_BYTECODE_STARTS_EF = 18;
     // ERROR_INTRINSIC_INVALID_SIGNATURE indicates the transaction is failing at the signature intrinsic check
-    ERROR_INTRINSIC_INVALID_SIGNATURE = 21;
+    ERROR_INTRINSIC_INVALID_SIGNATURE = 19;
     // ERROR_INTRINSIC_INVALID_CHAIN_ID indicates the transaction is failing at the chain id intrinsic check
-    ERROR_INTRINSIC_INVALID_CHAIN_ID = 22;
+    ERROR_INTRINSIC_INVALID_CHAIN_ID = 20;
     // ERROR_INTRINSIC_INVALID_NONCE indicates the transaction is failing at the nonce intrinsic check
-    ERROR_INTRINSIC_INVALID_NONCE = 23;
+    ERROR_INTRINSIC_INVALID_NONCE = 21;
     // ERROR_INTRINSIC_INVALID_GAS indicates the transaction is failing at the gas limit intrinsic check
-    ERROR_INTRINSIC_INVALID_GAS_LIMIT = 24;
+    ERROR_INTRINSIC_INVALID_GAS_LIMIT = 22;
     // ERROR_INTRINSIC_INVALID_BALANCE indicates the transaction is failing at balance intrinsic check
-    ERROR_INTRINSIC_INVALID_BALANCE = 25;
+    ERROR_INTRINSIC_INVALID_BALANCE = 23;
     // ERROR_INTRINSIC_INVALID_BATCH_GAS_LIMIT indicates the batch is exceeding the batch gas limit
-    ERROR_INTRINSIC_INVALID_BATCH_GAS_LIMIT = 26;
-    // ERROR_INTRINSIC_INVALID_SENDER_CODE indicates the batch is exceeding the batch gas limit
-    ERROR_INTRINSIC_INVALID_SENDER_CODE = 27;
+    ERROR_INTRINSIC_INVALID_BATCH_GAS_LIMIT = 24;
+    // ERROR_INTRINSIC_INVALID_SENDER_CODE indicates the transaction sender is invalid
+    ERROR_INTRINSIC_INVALID_SENDER_CODE = 25;
+    // ERROR_INTRINSIC_TX_GAS_OVERFLOW indicates the transaction gasLimit*gasPrice > MAX_UINT_256 - 1
+    ERROR_INTRINSIC_TX_GAS_OVERFLOW = 26;
     // ERROR_BATCH_DATA_TOO_BIG indicates the batch_l2_data is too big to be processed
-    ERROR_BATCH_DATA_TOO_BIG = 28;
+    ERROR_BATCH_DATA_TOO_BIG = 27;
 }


### PR DESCRIPTION
This PR does the following:
- separate `invalid` error into more specific errors