### PR TITLE
Add fork_id to GetStatusResponse

### DIFF
--- a/proto/aggregator/v1/aggregator.proto
+++ b/proto/aggregator/v1/aggregator.proto
@@ -146,6 +146,7 @@ message GetStatusResponse {
     uint64 number_of_cores = 11;
     uint64 total_memory = 12;
     uint64 free_memory = 13;
+    uint64 fork_id = 14
 }
 
 /**

--- a/proto/aggregator/v1/aggregator.proto
+++ b/proto/aggregator/v1/aggregator.proto
@@ -146,7 +146,7 @@ message GetStatusResponse {
     uint64 number_of_cores = 11;
     uint64 total_memory = 12;
     uint64 free_memory = 13;
-    uint64 fork_id = 14
+    uint64 fork_id = 14;
 }
 
 /**


### PR DESCRIPTION
This field will be used by the prover to inform about its supported fork_id