### PR TITLE
Add type at contract struct

### DIFF
--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -162,6 +162,8 @@ message Contract {
     string value = 3;
     bytes data = 4;
     uint64 gas = 5;
+    // Define type of internal call: CREATE, CREATE2, CALL, CALLCODE, DELEGATECALL, STATICCALL
+    string type = 6;
 }
 
 message ProcessTransactionResponse {

--- a/test/hashdb.test.js
+++ b/test/hashdb.test.js
@@ -2,7 +2,7 @@ const protoLoader = require('@grpc/proto-loader');
 const grpc = require('@grpc/grpc-js');
 
 describe('Compile mt proto', () => {
-    const PROTO_PATH = `${__dirname}/../proto/statedb/v1/statedb.proto`;
+    const PROTO_PATH = `${__dirname}/../proto/hashdb/v1/hashdb.proto`;
 
     it('compile', async () => {
         const packageDefinition = protoLoader.loadSync(


### PR DESCRIPTION
We need to add type param at Contract struct to replicate geth built in callTracer.
https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers#call-tracer

+ fixed tests