### PR TITLE
improve errors

### DIFF
--- a/proto/aggregator/v1/aggregator.proto
+++ b/proto/aggregator/v1/aggregator.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package aggregator.v1;
 
-option go_package = "github.com/0xPolygonHermez/zkevm-node/proverclient/prover";
+option go_package = "github.com/0xPolygonHermez/zkevm-node/proverclient/pb";
 
 message Version {
     string v0_0_1 = 1;
@@ -261,20 +261,10 @@ message PublicInputs {
     uint64 chain_id = 4;
     uint64 fork_id = 5;
     bytes batch_l2_data = 6;
-    bytes l1_info_root = 7;
-    uint64 timestamp_limit = 8;
+    bytes global_exit_root = 7;
+    uint64 eth_timestamp = 8;
     string sequencer_addr = 9;
-    bytes forced_blockhash_l1 = 10;
-    string aggregator_addr = 12;
-    map<uint32, L1Data> l1_info_tree_data = 16;
-}
-
-// l1InfoTree leaf values
-message L1Data {
-    bytes global_exit_root = 1;
-    bytes blockhash_l1 = 2;
-    uint32 min_timestamp = 3;
-    repeated bytes smt_proof = 4;
+    string aggregator_addr = 10;
 }
 
 /**

--- a/proto/aggregator/v1/aggregator.proto
+++ b/proto/aggregator/v1/aggregator.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package aggregator.v1;
 
-option go_package = "github.com/0xPolygonHermez/zkevm-node/proverclient/pb";
+option go_package = "github.com/0xPolygonHermez/zkevm-node/proverclient/prover";
 
 message Version {
     string v0_0_1 = 1;
@@ -261,10 +261,20 @@ message PublicInputs {
     uint64 chain_id = 4;
     uint64 fork_id = 5;
     bytes batch_l2_data = 6;
-    bytes global_exit_root = 7;
-    uint64 eth_timestamp = 8;
+    bytes l1_info_root = 7;
+    uint64 timestamp_limit = 8;
     string sequencer_addr = 9;
-    string aggregator_addr = 10;
+    bytes forced_blockhash_l1 = 10;
+    string aggregator_addr = 12;
+    map<uint32, L1Data> l1_info_tree_data = 16;
+}
+
+// l1InfoTree leaf values
+message L1Data {
+    bytes global_exit_root = 1;
+    bytes blockhash_l1 = 2;
+    uint32 min_timestamp = 3;
+    repeated bytes smt_proof = 4;
 }
 
 /**

--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -817,4 +817,6 @@ enum ExecutorError {
     EXECUTOR_ERROR_INVALID_L1_SMT_PROOF = 101;
     // EXECUTOR_ERROR_INVALID_BALANCE indicates that the input parameter balance value is invalid
     EXECUTOR_ERROR_INVALID_BALANCE = 102;
+    // EXECUTOR_ERROR_SM_MAIN_BINARY_LT4_MISMATCH indicates that the binary instruction less than four opcode failed
+    EXECUTOR_ERROR_SM_MAIN_BINARY_LT4_MISMATCH = 103;
 }

--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -323,6 +323,8 @@ message ProcessBatchResponseV2 {
     repeated bytes smt_keys = 20;
     repeated bytes program_keys = 21;
     uint64 fork_id = 22;
+    uint32 invalid_batch = 23;
+    RomError error_rom = 24;
 }
 
 // Trace configuration request params
@@ -470,6 +472,8 @@ message ProcessBlockResponseV2 {
     repeated ProcessTransactionResponseV2 responses = 11;
     // All Logs emited by LOG opcode during the block
     repeated LogV2 logs = 12;
+    // Any error encountered during block execution
+    RomError error = 13;
 }
 
 message ProcessTransactionResponseV2 {
@@ -608,8 +612,10 @@ enum RomError {
     ROM_ERROR_INVALID_DECODE_CHANGE_L2_BLOCK = 31;
     // ROM_ERROR_INVALID_NOT_FIRST_TX_CHANGE_L2_BLOCK indicates that the first transaction in a batch is not a change l2 block transaction
     ROM_ERROR_INVALID_NOT_FIRST_TX_CHANGE_L2_BLOCK = 32;
-    // ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK indicates that the change l2 block transaction has trigger an error during while executing
-    ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK = 33;
+    // ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_LIMIT_TIMESTAMP indicates that the change l2 block transaction has trigger an error during while executing
+    ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_LIMIT_TIMESTAMP = 33;
+    // ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_MIN_TIMESTAMP indicates that the change l2 block transaction has trigger an error during while executing
+    ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_MIN_TIMESTAMP = 34;
 }
 
 enum ExecutorError {

--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -291,6 +291,7 @@ message ProcessBatchRequestV2 {
     // where each entry specifies some state to be ephemerally overridden
     // prior to executing the call.
     map<string, OverrideAccountV2> state_override = 23;
+    DebugV2 debug = 24;
 }
 
 message L1DataV2 {
@@ -298,6 +299,10 @@ message L1DataV2 {
     bytes block_hash_l1 = 2;
     uint64 min_timestamp = 3;
     repeated bytes smt_proof = 4;
+}
+
+message DebugV2 {
+    uint64 gas_limit = 1;
 }
 
 message ProcessBatchResponseV2 {

--- a/proto/executor/v1/executor.proto
+++ b/proto/executor/v1/executor.proto
@@ -303,6 +303,10 @@ message L1DataV2 {
 
 message DebugV2 {
     uint64 gas_limit = 1;
+    bytes new_state_root = 2; 
+    bytes new_acc_input_hash = 3;
+    bytes new_local_exit_root = 4;
+    uint64 new_batch_num = 5;
 }
 
 message ProcessBatchResponseV2 {
@@ -328,6 +332,8 @@ message ProcessBatchResponseV2 {
     repeated bytes smt_keys = 20;
     repeated bytes program_keys = 21;
     uint64 fork_id = 22;
+    uint32 invalid_batch = 23;
+    RomError error_rom = 24;
 }
 
 // Trace configuration request params
@@ -475,6 +481,8 @@ message ProcessBlockResponseV2 {
     repeated ProcessTransactionResponseV2 responses = 11;
     // All Logs emited by LOG opcode during the block
     repeated LogV2 logs = 12;
+    // Any error encountered during block execution
+    RomError error = 13;
 }
 
 message ProcessTransactionResponseV2 {
@@ -613,8 +621,10 @@ enum RomError {
     ROM_ERROR_INVALID_DECODE_CHANGE_L2_BLOCK = 31;
     // ROM_ERROR_INVALID_NOT_FIRST_TX_CHANGE_L2_BLOCK indicates that the first transaction in a batch is not a change l2 block transaction
     ROM_ERROR_INVALID_NOT_FIRST_TX_CHANGE_L2_BLOCK = 32;
-    // ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK indicates that the change l2 block transaction has trigger an error during while executing
-    ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK = 33;
+    // ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_LIMIT_TIMESTAMP indicates that the change l2 block transaction has trigger an error during while executing
+    ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_LIMIT_TIMESTAMP = 33;
+    // ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_MIN_TIMESTAMP indicates that the change l2 block transaction has trigger an error during while executing
+    ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_MIN_TIMESTAMP = 34;
 }
 
 enum ExecutorError {
@@ -826,4 +836,10 @@ enum ExecutorError {
     EXECUTOR_ERROR_INVALID_BALANCE = 102;
     // EXECUTOR_ERROR_SM_MAIN_BINARY_LT4_MISMATCH indicates that the binary instruction less than four opcode failed
     EXECUTOR_ERROR_SM_MAIN_BINARY_LT4_MISMATCH = 103;
+    // EXECUTOR_ERROR_INVALID_NEW_STATE_ROOT indicates that the input parameter new_state_root is invalid
+    EXECUTOR_ERROR_INVALID_NEW_STATE_ROOT = 104;
+    // EXECUTOR_ERROR_INVALID_NEW_ACC_INPUT_HASH indicates that the input parameter new_acc_input_hash is invalid
+    EXECUTOR_ERROR_INVALID_NEW_ACC_INPUT_HASH = 105;
+    // EXECUTOR_ERROR_INVALID_NEW_LOCAL_EXIT_ROOT indicates that the input parameter new_local_exit_root is invalid
+    EXECUTOR_ERROR_INVALID_NEW_LOCAL_EXIT_ROOT = 106;
 }

--- a/proto/hashdb/v1/hashdb.proto
+++ b/proto/hashdb/v1/hashdb.proto
@@ -28,8 +28,10 @@ service HashDBService {
     rpc GetProgram(GetProgramRequest) returns (GetProgramResponse) {}
     rpc LoadDB(LoadDBRequest) returns (google.protobuf.Empty) {}
     rpc LoadProgramDB(LoadProgramDBRequest) returns (google.protobuf.Empty) {}
+    rpc FinishTx (FinishTxRequest) returns (google.protobuf.Empty) {}
+    rpc StartBlock (StartBlockRequest) returns (google.protobuf.Empty) {}
+    rpc FinishBlock (FinishBlockRequest) returns (google.protobuf.Empty) {}
     rpc Flush (FlushRequest) returns (FlushResponse) {}
-    rpc SemiFlush (SemiFlushRequest) returns (google.protobuf.Empty) {}
     rpc GetFlushStatus (google.protobuf.Empty) returns (GetFlushStatusResponse) {}
     rpc GetFlushData (GetFlushDataRequest) returns (GetFlushDataResponse) {}
     rpc ConsolidateState (ConsolidateStateRequest) returns (ConsolidateStateResponse) {}
@@ -152,12 +154,36 @@ message FlushRequest {
 }
 
 /**
- * @dev SemiFlushRequest
- * @param {batch_uuid} - indicates a unique identifier of the current batch or session which data will be semi-flushed
+ * @dev FinishTxRequest
+ * @param {batch_uuid} - indicates a unique identifier of the current batch or session which tx will be finished
  * @param {new_state_root} - state root at this point of the execution
  * @param {persistence} - indicates if it should be stored only in CACHE, in the SQL DATABASE, or it is just TEMPORARY and should be deleted at the flush of this batch UUID
  */
-message SemiFlushRequest {
+message FinishTxRequest {
+    string batch_uuid = 1;
+    string new_state_root = 2;
+    Persistence persistence = 3;
+}
+
+/**
+ * @dev StartBlockRequest
+ * @param {batch_uuid} - indicates a unique identifier of the current batch or session which block started
+ * @param {new_state_root} - state root at this point of the execution
+ * @param {persistence} - indicates if it should be stored only in CACHE, in the SQL DATABASE, or it is just TEMPORARY and should be deleted at the flush of this batch UUID
+ */
+message StartBlockRequest {
+    string batch_uuid = 1;
+    string old_state_root = 2;
+    Persistence persistence = 3;
+}
+
+/**
+ * @dev FinishBlockRequest
+ * @param {batch_uuid} - indicates a unique identifier of the current batch or session which block will be finished
+ * @param {new_state_root} - state root at this point of the execution
+ * @param {persistence} - indicates if it should be stored only in CACHE, in the SQL DATABASE, or it is just TEMPORARY and should be deleted at the flush of this batch UUID
+ */
+message FinishBlockRequest {
     string batch_uuid = 1;
     string new_state_root = 2;
     Persistence persistence = 3;
@@ -240,6 +266,8 @@ message GetLatestStateRootResponse {
  * @param {proof_hash_counter}
  * @param {db_read_log} - list of db records read during the execution of the request
  * @param {result} - result code
+ * @param {sibling_left_child} - on delete not found, use children to hash intermediate node (to be sure that it's a intermediate)
+ * @param {sibling_right_child} - on delete not found, use children to hash intermediate node (to be sure that it's a intermediate)
  */
 message SetResponse {
     Fea old_root = 1;
@@ -255,6 +283,8 @@ message SetResponse {
     uint64 proof_hash_counter = 11;
     map<string, FeList> db_read_log = 12;
     ResultCode result = 13;
+    Fea sibling_left_child = 14;
+    Fea sibling_right_child = 15;
 }
 
 /**


### PR DESCRIPTION
This PR does the following:
- adds two new fields at batch level
  - `invalid_batch`: indicates if the batch has been invalidated (no state-root change)
  - `error_rom`: indicates which error reason has been triggered in the rom that has been invalidate the batch
- add a new filed at block level
  - `error`: indicates error at block level
    - example: any out-of-counters at block level
- rom errors
  - split error `ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK` in two errors to get better error information:
    - `ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_LIMIT_TIMESTAMP`
    - `ROM_ERROR_INVALID_TX_CHANGE_L2_BLOCK_MIN_TIMESTAMP` 